### PR TITLE
Make loading of resampy and audiofile optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,14 @@ audtorch_ is supported by Python 3.5 or higher. To install it run
 
     pip install audtorch
 
+In order to have as few dependencies as possible for the package not all
+packages that are needed for some functionalities are installed. If you want to
+install all dependencies run:
+
+.. code-block:: bash
+
+    pip install audiofile librosa
+
 .. _audtorch: https://audtorch.readthedocs.io
 .. _virtual environment: https://docs.python-guide.org/dev/virtualenvs
 

--- a/audtorch/datasets/common.py
+++ b/audtorch/datasets/common.py
@@ -1,7 +1,10 @@
 import os
 from warnings import warn
 
-import resampy
+try:
+    import resampy
+except ImportError:
+    resampy = None
 from torch.utils.data import Dataset
 
 from .utils import (load, sampling_rate_after_transform)

--- a/audtorch/datasets/utils.py
+++ b/audtorch/datasets/utils.py
@@ -2,7 +2,10 @@ import subprocess
 from warnings import warn
 
 import numpy as np
-import audiofile as af
+try:
+    import audiofile as af
+except ImportError:
+    af = None
 
 
 def load(filename, duration=None, offset=0):

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
     :start-line: 22
-    :end-line: 36
+    :end-line: 44

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,2 +1,2 @@
 .. include:: ../README.rst
-    :start-line: 36
+    :start-line: 44

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,8 @@ setup(
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     install_requires=[
-        'numpy',
-        'audiofile',
-        'resampy',
         'torch',
+        'numpy',
     ],
     author=('Andreas Triantafyllopoulos, '
             'Stephan Huber, '


### PR DESCRIPTION
## Summary

This proposes a solution to have only `numpy` and `torch` as needed dependencies in order to install `audtorch`.
All other packages are tried to import and set to `None` if the import fails, which of course results in an error when they are needed during runtime.

## Changes
This affects the execution of the following parts:
* `stft` and `istft` will only work if `librosa` is installed
* `datasets.load` will only work if `audiofile` is installed
* `AudioDatasets` with data sets that have different sampling rates will only work if `resampy` is installed

## Discussion

1. This allows the user to use only parts of `audtorch` without requiring to install all needed packages, which might be of interest for production.
2. Unfortunately, the current approach results in a not so meaningful error message when a package is missing as we simply set it to `None`