### PR TITLE
Remove download from datasets.AudioDataset

### DIFF
--- a/audtorch/datasets/common.py
+++ b/audtorch/datasets/common.py
@@ -56,7 +56,7 @@ class AudioDataset(Dataset):
     """
 
     def __init__(self, root, files, targets, sampling_rate, *, transform=None,
-                 target_transform=None, download=False):
+                 target_transform=None):
         self.root = os.path.expanduser(root)
         self.files = [os.path.join(self.root, f) for f in files]
         self.targets = targets
@@ -65,9 +65,6 @@ class AudioDataset(Dataset):
         self.target_transform = target_transform
 
         assert len(files) == len(targets)
-
-        if download:
-            self._download()
 
         if not self._check_exists():
             raise RuntimeError('Dataset not found.')
@@ -102,11 +99,6 @@ class AudioDataset(Dataset):
     @property
     def sampling_rate(self):
         return sampling_rate_after_transform(self)
-
-    def _download(self):
-        if self._check_exists():
-            return
-        print('This data set provides no download functionality')
 
     def _check_exists(self):
         return os.path.exists(self.root)
@@ -199,14 +191,14 @@ class PandasDataset(AudioDataset):
 
     def __init__(self, root, df, sampling_rate, *, column_labels='label',
                  column_filename='filename', transform=None,
-                 target_transform=None, download=False):
+                 target_transform=None):
         files, labels = \
             files_and_labels_from_df(df, root=root,
                                      column_labels=column_labels,
                                      column_filename=column_filename)
         super().__init__(root, files, targets=labels,
                          sampling_rate=sampling_rate, transform=transform,
-                         target_transform=target_transform, download=download)
+                         target_transform=target_transform)
         self.column_labels = column_labels
 
     def extra_repr(self):
@@ -274,12 +266,9 @@ class CsvDataset(PandasDataset):
 
     def __init__(self, root, csv_file, sampling_rate, *, sep=',',
                  column_labels='label', column_filename='filename',
-                 transform=None, target_transform=None, download=False):
+                 transform=None, target_transform=None):
         self.root = os.path.expanduser(root)
         self.csv_file = os.path.join(self.root, csv_file)
-
-        if download:
-            self._download()
 
         if not os.path.isfile(self.csv_file):
             raise FileNotFoundError('CSV file {} not found.'

--- a/audtorch/datasets/speech.py
+++ b/audtorch/datasets/speech.py
@@ -1,5 +1,6 @@
-from .utils import (download_url, extract_archive)
+import os
 
+from .utils import (download_url, extract_archive)
 from .common import CsvDataset
 
 
@@ -79,10 +80,15 @@ class MozillaCommonVoice(CsvDataset):
     def __init__(self, root, *, csv_file='cv-valid-train.csv',
                  label_type='text', transform=None, target_transform=None,
                  download=False):
+
+        if download:
+            self.root = os.path.expanduser(root)
+            self._download()
+
         super().__init__(root, csv_file, sampling_rate=48000, sep=',',
                          column_labels=label_type, column_filename='filename',
                          transform=transform,
-                         target_transform=target_transform, download=download)
+                         target_transform=target_transform)
 
     def _download(self):
         if self._check_exists():


### PR DESCRIPTION
## Summary

It makes not really sense to provide the `self._download` method already in the `AudioDataset`. I removed it there and it is then added in those data sets that actually provide download, e.g. MozillaCommonVoice.