### PR TITLE
Add utils.flatten_list

### DIFF
--- a/audtorch/utils.py
+++ b/audtorch/utils.py
@@ -1,4 +1,36 @@
+from copy import deepcopy
+
 import numpy as np
+
+
+def flatten_list(nested_list):
+    """Flatten an arbitrarily nested list.
+
+    Implemented without  recursion to avoid stack overflows.
+    Returns a new list, the original list is unchanged.
+
+    Args:
+        nested_list (list): nested list
+
+    Returns:
+        list: flattened list
+
+    Example:
+        >>> flatten_list([1, 2, 3, [4], [], [[[[[[[[[5]]]]]]]]]])
+        [1, 2, 3, 4, 5]
+        >>> flatten_list([[1, 2], 3])
+        [1, 2, 3]
+
+    """
+    def _flat_generator(nested_list):
+        while nested_list:
+            sublist = nested_list.pop(0)
+            if isinstance(sublist, list):
+                nested_list = sublist + nested_list
+            else:
+                yield sublist
+    nested_list = deepcopy(nested_list)
+    return list(_flat_generator(nested_list))
 
 
 def to_tuple(input, *, tuple_len=2):

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -5,6 +5,11 @@ Utility functions.
 
 .. automodule:: audtorch.utils
 
+flatten_list
+------------
+
+.. autofunction:: flatten_list
+
 to_tuple
 --------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,16 @@ import audtorch as at
 xfail = pytest.mark.xfail
 
 
+@pytest.mark.parametrize('nested_list,expected_list', [
+    ([1, 2, 3, [4], [], [[[[[[[[[5]]]]]]]]]], [1, 2, 3, 4, 5]),
+    ([[1, 2], 3], [1, 2, 3]),
+    ([1, 2, 3], [1, 2, 3]),
+])
+def test_flatten_list(nested_list, expected_list):
+    flattened_list = at.utils.flatten_list(nested_list)
+    assert flattened_list == expected_list
+
+
 @pytest.mark.parametrize('input,tuple_len,expected_output', [
     ('aa', 2, ('a', 'a')),
     (2, 1, (2,)),


### PR DESCRIPTION
## Summary

This adds the utility function `utils.flatten_list`, which provides a non-recursive way of flatten any kind of nested list, e.g.
```python
>>> flatten_list([1, 2, 3, [4], [], [[[[[[[[[5]]]]]]]]]])
[1, 2, 3, 4, 5]
```