### PR TITLE
DOC: fix build on RTD without installing package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
   - pip install -r tests/requirements.txt
 script:
   - python -m pytest
-  - python -m sphinx -W docs/ docs/_build/ -b html
+  - python -m sphinx -W docs/ docs/_build/ -b html -W

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -106,13 +106,13 @@ You can install it and a few other necessary packages with::
 
 To create the HTML pages, use::
 
-    python setup.py build_sphinx
+    sphinx-build docs/ build/sphinx/html/ -b html
 
 The generated files will be available in the directory ``build/sphinx/html/``.
 
 It is also possible to automatically check if all links are still valid::
 
-    python setup.py build_sphinx -b linkcheck
+    sphinx-build docs/ build/sphinx/html/ -b linkcheck
 
 .. _Sphinx: http://sphinx-doc.org/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,26 @@
+import os
+import sys
 from subprocess import check_output
+
+
+# Import ------------------------------------------------------------------
+
+# Relative source code path. Avoids `import audtorch`, which need package to be
+# installed first.
+sys.path.insert(0, os.path.abspath('..'))
+
+# Ignore package dependencies during building the docs
+autodoc_mock_imports = [
+    'audiofile',
+    'librosa',
+    'numpy',
+    'pandas',
+    'resampy',
+    'torch',
+    'scipy',
+    'tqdm',
+    'tabulate',
+]
 
 
 # Project -----------------------------------------------------------------
@@ -43,19 +65,6 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'torch': ('https://pytorch.org/docs/stable/', None),
 }
-
-# Ignore package dependencies during building the docs
-autodoc_mock_imports = [
-    'audiofile',
-    'librosa',
-    'numpy',
-    'pandas',
-    'resampy',
-    'torch',
-    'scipy',
-    'tqdm',
-    'tabulate',
-]
 
 # HTML --------------------------------------------------------------------
 


### PR DESCRIPTION
### Summary

The API documentation is broken on readthedocs for the 0.1.0 release as its configuration needed the package to be installed and imported. As installing the package requires large dependencies like torch, this is not desired.

This PR avoids the need to install the package by adding its path to `sys.path` in `conf.py` of the docs.


### Proposed Changes

* Update `conf.py`
* Update documentation building command in `CONTRIBUTING.rst`
* Update documentation building test on travis to fail on warnings


### Discussion

This error did not happen locally as we always built the documentation with
```bash
$ python setup.py build_sphinx
```
If you use the command that readthedocs is executing we will get the same error:
```bash
sphinx-build docs/ build/sphinx/html/ -b html
```
which is now fixed.

To be aware of testing this command, I changed also `CONTRIBUTING.rst` to use this command for building the docs.