### PR TITLE
DOC: add link to RTD page to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,7 @@ audtorch
 
 Deep learning with PyTorch_ and audio.
 
-audtorch_ collects audio related data sets, transforms and other useful
-additions that are useful.
+**Documentation:** https://audtorch.readthedocs.io
 
 If you are interested in PyTorch_ and audio you should also check out the
 efforts to integrate more audio directly into PyTorch_:
@@ -16,7 +15,6 @@ efforts to integrate more audio directly into PyTorch_:
 * `keunwoochoi/torchaudio-contrib`_
 
 .. _PyTorch: https://pytorch.org
-.. _audtorch: https://audtorch.readthedocs.io
 .. _pytorch/audio: https://github.com/pytorch/audio
 .. _keunwoochoi/torchaudio-contrib:
     https://github.com/keunwoochoi/torchaudio-contrib

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 .. audtorch documentation master file
 
 .. include:: ../README.rst
-    :end-line: 33
+    :end-line: 31
 
 .. toctree::
     :caption: Getting started

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,3 +1,3 @@
 .. include:: ../README.rst
-    :start-line: 34
-    :end-line: 47
+    :start-line: 32
+    :end-line: 45

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,2 +1,2 @@
 .. include:: ../README.rst
-    :start-line: 48
+    :start-line: 46


### PR DESCRIPTION
### Summary

Adds a link to the online documentation in a more prominent position.

It also removes the second introduction sentence as I don't think it is needed there as we have the usage section.