### PR TITLE
Fix normalize axis

### DIFF
--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -249,7 +249,7 @@ def normalize(signal, *, axis=None):
                [0.75, 1.  ]])
 
     """
-    if axis != None:
+    if axis is not None:
         peak = np.expand_dims(np.amax(np.abs(signal), axis=axis), axis=axis)
     else:
         peak = np.amax(np.abs(signal))

--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -249,7 +249,7 @@ def normalize(signal, *, axis=None):
                [0.75, 1.  ]])
 
     """
-    if axis:
+    if axis != None:
         peak = np.expand_dims(np.amax(np.abs(signal), axis=axis), axis=axis)
     else:
         peak = np.amax(np.abs(signal))

--- a/tests/test_transforms_functional.py
+++ b/tests/test_transforms_functional.py
@@ -115,6 +115,8 @@ def test_additivemix(input1, input2, ratio, percentage_silence,
                       [a21 / max(a21), a22 / max(a22)]])),
     (a11, None, a11 / np.max(a11)),
     (a11, -1, a11 / np.max(a11)),
+    ([a11, a12], 1, np.array([a11 / max(a11), a12 / max(a12)])),
+    ([[1, 4], [3, 2]], 0, np.array([[1 / 3, 4 / 4], [3 / 3, 2 / 4]])),
 ])
 def test_normalize(input, axis, expected_output):
     output = F.normalize(input, axis=axis)


### PR DESCRIPTION
### Summary

This pull-request fixes `transforms.Normalize` and `transforms.functional.normalize` for the case when `axis=0`.

This `if-branch`: https://github.com/audeering/audtorch/blob/b575ba527af7d839af3f50ea54915dc92d225f23/audtorch/transforms/functional.py#L252 is also triggered by `axis=0`, which results in the matrix being normalized by its global maximum absolute value, and not by the local one in axis 0.

### Proposed Changes

* Change `if axis` to `if axis is not None`
* Add tests for 2D matrices with `axis=0` and `axis=1`


### Discussion

This should also increase the patch version as it implements a bug fix.