### PR TITLE
Spectrogram reform

### DIFF
--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -256,7 +256,7 @@ def normalize(signal, *, axis=None):
     return signal / np.maximum(peak, 1e-7)
 
 
-def standardize(signal, *, axis=None, mean=True, std=True):
+def standardize(signal, *, mean=True, std=True, axis=None):
     r"""Standardize signal.
 
     Ensure the signal has a mean value of 0 and a variance of 1.

--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -289,9 +289,9 @@ def standardize(signal, axis=None):
 
 
 def stft(signal, window_size, hop_size, *, n_fft=None, window='hann', axis=-1):
-    r"""Short-term Fourier transform.
+    r"""Short-time Fourier transform.
 
-    The short-term Fourier transform (STFT) is calculated by using librosa.
+    The Short-time Fourier transform (STFT) is calculated by using librosa.
     It returns an array with the same shape as the input array, besides the
     axis chosen for STFT calculation is replaced by the two new ones of the
     spectrogram.
@@ -336,9 +336,9 @@ def stft(signal, window_size, hop_size, *, n_fft=None, window='hann', axis=-1):
 
 
 def istft(spectrogram, window_size, hop_size, *, window='hann', axis=-2):
-    r"""Inverse short-term Fourier transform.
+    r"""Inverse Short-time Fourier transform.
 
-    The inverse short-term Fourier transform (iSTFT) is calculated by using
+    The inverse Short-time Fourier transform (iSTFT) is calculated by using
     librosa.
     It handles multi-dimensional inputs, but assumes that the two spectrogram
     axis are beside each other, starting with the axis corresponding to
@@ -389,7 +389,7 @@ def istft(spectrogram, window_size, hop_size, *, window='hann', axis=-2):
 
 
 def _istft(spectrogram, frequency_bins, time_bins, **config):
-    """Inverse short-term Fourier transform from a single axis.
+    """Inverse Short-time Fourier transform from a single axis.
 
     Time and frequency bins have to be provided in a single vector. This allows
     effective computation using `numpy.apply_along_axis`.

--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -256,6 +256,38 @@ def normalize(signal, *, axis=None):
     return signal / np.maximum(peak, 1e-7)
 
 
+def standardize(signal, axis=None):
+    r"""Standardize signal.
+
+    Ensure the signal has a mean value of 0 and a variance of 1.
+
+    Note:
+        The signal will never be divided by a variance smaller than 1e-7.
+
+    Args:
+        signal (numpy.ndarray): audio signal
+        axis (int, optional): standardize only along the given axis.
+            Default: `None`
+
+    Returns:
+        numpy.ndarray: standardized signal
+
+    Example:
+        >>> a = np.array([[1, 2], [3, 4]])
+        >>> standardize(a)
+        array([[-1.34164079, -0.4472136 ],
+               [ 0.4472136 ,  1.34164079]])
+
+    """
+    if axis is not None:
+        mean = np.expand_dims(np.mean(signal, axis=axis), axis=axis)
+        std = np.expand_dims(np.std(signal, axis=axis), axis=axis)
+    else:
+        mean = np.mean(signal)
+        std = np.std(signal)
+    return (signal - mean) / np.maximum(std, 1e-7)
+
+
 def stft(signal, window_size, hop_size, *, n_fft=None, window='hann', axis=-1):
     r"""Short-term Fourier transform.
 

--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -283,15 +283,15 @@ def standardize(signal, axis=None, mean=True, std=True):
 
     """
     if axis is not None:
-        mean = np.expand_dims(np.mean(signal, axis=axis), axis=axis)
-        std = np.expand_dims(np.std(signal, axis=axis), axis=axis)
+        signal_mean = np.expand_dims(np.mean(signal, axis=axis), axis=axis)
+        signal_std = np.expand_dims(np.std(signal, axis=axis), axis=axis)
     else:
-        mean = np.mean(signal)
-        std = np.std(signal)
+        signal_mean = np.mean(signal)
+        signal_std = np.std(signal)
     if mean:
-        signal = signal - mean
+        signal = signal - signal_mean
     if std:
-        signal = signal / np.maximum(std, 1e-7)
+        signal = signal / np.maximum(signal_std, 1e-7)
     return signal
 
 

--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -288,7 +288,8 @@ def standardize(signal, axis=None):
     return (signal - mean) / np.maximum(std, 1e-7)
 
 
-def stft(signal, window_size, hop_size, *, n_fft=None, window='hann', axis=-1):
+def stft(signal, window_size, hop_size, *, fft_size=None, window='hann',
+         axis=-1):
     r"""Short-time Fourier transform.
 
     The Short-time Fourier transform (STFT) is calculated by using librosa.
@@ -327,9 +328,9 @@ def stft(signal, window_size, hop_size, *, n_fft=None, window='hann', axis=-1):
     # Pad to ensure same signal length after reconstruction
     # See discussion at https://github.com/librosa/librosa/issues/328
     signal = pad(signal, (0, np.mod(samples, hop_size)), value=0, axis=axis)
-    if n_fft is None:
-        n_fft = window_size
-    fft_config = dict(n_fft=n_fft, hop_length=hop_size,
+    if fft_size is None:
+        fft_size = window_size
+    fft_config = dict(n_fft=fft_size, hop_length=hop_size,
                       win_length=window_size, window=window)
     spectrogram = np.apply_along_axis(librosa.stft, axis, signal, **fft_config)
     return spectrogram

--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -256,7 +256,7 @@ def normalize(signal, *, axis=None):
     return signal / np.maximum(peak, 1e-7)
 
 
-def standardize(signal, axis=None, mean=True, std=True):
+def standardize(signal, *, axis=None, mean=True, std=True):
     r"""Standardize signal.
 
     Ensure the signal has a mean value of 0 and a variance of 1.
@@ -266,11 +266,10 @@ def standardize(signal, axis=None, mean=True, std=True):
 
     Args:
         signal (numpy.ndarray): audio signal
-        axis (int, optional): standardize only along the given axis.
-            Default: `None`
         mean (bool, optional): apply mean centering. Default: `True`
         std (bool, optional): normalize by standard deviation. Default: `True`
-
+        axis (int, optional): standardize only along the given axis.
+            Default: `None`
 
     Returns:
         numpy.ndarray: standardized signal

--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -256,7 +256,7 @@ def normalize(signal, *, axis=None):
     return signal / np.maximum(peak, 1e-7)
 
 
-def stft(signal, window_size, hop_size, *, window='hann', axis=-1):
+def stft(signal, window_size, hop_size, *, n_fft=None, window='hann', axis=-1):
     r"""Short-term Fourier transform.
 
     The short-term Fourier transform (STFT) is calculated by using librosa.
@@ -295,7 +295,9 @@ def stft(signal, window_size, hop_size, *, window='hann', axis=-1):
     # Pad to ensure same signal length after reconstruction
     # See discussion at https://github.com/librosa/librosa/issues/328
     signal = pad(signal, (0, np.mod(samples, hop_size)), value=0, axis=axis)
-    fft_config = dict(n_fft=window_size, hop_length=hop_size,
+    if n_fft is None:
+        n_fft = window_size
+    fft_config = dict(n_fft=n_fft, hop_length=hop_size,
                       win_length=window_size, window=window)
     spectrogram = np.apply_along_axis(librosa.stft, axis, signal, **fft_config)
     return spectrogram

--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -281,15 +281,15 @@ def standardize(signal, *, axis=None, mean=True, std=True):
                [ 0.4472136 ,  1.34164079]])
 
     """
-    if axis is not None:
-        signal_mean = np.expand_dims(np.mean(signal, axis=axis), axis=axis)
-        signal_std = np.expand_dims(np.std(signal, axis=axis), axis=axis)
-    else:
-        signal_mean = np.mean(signal)
-        signal_std = np.std(signal)
     if mean:
+        signal_mean = np.mean(signal, axis=axis)
+        if axis is not None:
+            signal_mean = np.expand_dims(signal_mean, axis=axis)
         signal = signal - signal_mean
     if std:
+        signal_std = np.std(signal, axis=axis)
+        if axis is not None:
+            signal_std = np.expand_dims(signal_std, axis=axis)
         signal = signal / np.maximum(signal_std, 1e-7)
     return signal
 

--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -256,7 +256,7 @@ def normalize(signal, *, axis=None):
     return signal / np.maximum(peak, 1e-7)
 
 
-def standardize(signal, axis=None):
+def standardize(signal, axis=None, mean=True, std=True):
     r"""Standardize signal.
 
     Ensure the signal has a mean value of 0 and a variance of 1.
@@ -268,6 +268,9 @@ def standardize(signal, axis=None):
         signal (numpy.ndarray): audio signal
         axis (int, optional): standardize only along the given axis.
             Default: `None`
+        mean (bool, optional): apply mean centering. Default: `True`
+        std (bool, optional): normalize by standard deviation. Default: `True`
+
 
     Returns:
         numpy.ndarray: standardized signal
@@ -285,7 +288,11 @@ def standardize(signal, axis=None):
     else:
         mean = np.mean(signal)
         std = np.std(signal)
-    return (signal - mean) / np.maximum(std, 1e-7)
+    if mean:
+        signal = signal - mean
+    if std:
+        signal = signal / np.maximum(std, 1e-7)
+    return signal
 
 
 def stft(signal, window_size, hop_size, *, fft_size=None, window='hann',

--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -877,6 +877,7 @@ class Log(object):
                [1.1920928e-07, 1.0986123e+00, 1.0986123e+00]], dtype=float32)
 
     """
+
     def __init__(self, magnitude_boost=1e-7):
         self.magnitude_boost = magnitude_boost
 
@@ -946,6 +947,9 @@ class LogSpectrogram(object):
     def __init__(self, window_size, hop_size, *, window='hann',
                  normalize=False, magnitude_boost=1e-7, axis=-1):
         super().__init__()
+        warn('LogSpectrogram will be removed in a future version. '
+             'Please use a Compose transform consisting of Spectrogram and '
+             'Log instead.', DeprecationWarning)
         self.window_size = window_size
         self.hop_size = hop_size
         self.window = window

--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -863,8 +863,13 @@ class Log(object):
 
     Args:
         magnitude_boost (float, optional): positive value added to the
-            magnitude of the signal before applying the logarithmus.
-            Default: `1e-7`
+            magnitude of the signal before applying the logarithmus. Default:
+            `1e-7`
+
+    Shape:
+        - Input: :math:`(*)`
+        - Output: :math:`(*)`, where :math:`*` can be any additional number of
+          dimensions.
 
     Example:
         >>> a = np.array([1., 2., 3., 4.])

--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -818,6 +818,40 @@ class Spectrogram(object):
         return '{0}({1})'.format(self.__class__.__name__, options)
 
 
+class Log(object):
+    r"""Logarithmic transform of an input signal.
+
+    * :attr:`magnitude_boost` controls the positive value added to the
+      magnitude of the signal before applying the logarithmus
+
+    Args:
+        magnitude_boost (float, optional): positive value added to the
+            magnitude of the signal before applying the logarithmus.
+            Default: `1e-7`
+
+    Example:
+        >>> a = np.array([1., 2., 3., 4.])
+        >>> spect = Spectrogram(window_size=2, hop_size=2)
+        >>> t = Log()
+        >>> print(t)
+        Log(magnitude_boost=1e-07)
+        >>> t(spect(a))
+        array([[1.1920928e-07, 1.0986123e+00, 1.0986123e+00],
+               [1.1920928e-07, 1.0986123e+00, 1.0986123e+00]], dtype=float32)
+
+    """
+    def __init__(self, magnitude_boost=1e-7):
+        self.magnitude_boost = magnitude_boost
+
+    def __call__(self, signal):
+        signal = np.log(signal + self.magnitude_boost)
+        return signal
+
+    def __repr__(self):
+        options = ('magnitude_boost={}'.format(self.magnitude_boost))
+        return '{0}({1})'.format(self.__class__.__name__, options)
+
+
 class LogSpectrogram(object):
     r"""Logarithmic spectrogram of an audio signal.
 

--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -720,7 +720,7 @@ class Standardize(object):
 
 
 class Resample(object):
-    """Resample to new sampling rate.
+    r"""Resample to new sampling rate.
 
     The signal is resampled by one of the following methods.
 
@@ -858,7 +858,7 @@ class Spectrogram(object):
 class Log(object):
     r"""Logarithmic transform of an input signal.
 
-    * :attr:`magnitude_boost` controls the positive value added to the
+    * :attr:`magnitude_boost` controls the non-negative value added to the
       magnitude of the signal before applying the logarithmus
 
     Args:
@@ -879,6 +879,10 @@ class Log(object):
     """
     def __init__(self, magnitude_boost=1e-7):
         self.magnitude_boost = magnitude_boost
+
+        if self.magnitude_boost < 0:
+            raise ValueError('`magnitude_boost` has to be >=0, but is {}'
+                             .format(self.magnitude_boost))
 
     def __call__(self, signal):
         signal = np.log(signal + self.magnitude_boost)

--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -794,7 +794,7 @@ class Spectrogram(object):
 
     * :attr:`window_size` controls FFT window size in samples
     * :attr:`hop_size` controls STFT window hop size in samples
-    * :attr:`n_fft` controls number of frequency bins in STFT
+    * :attr:`fft_size` controls number of frequency bins in STFT
     * :attr:`window` controls window function of spectrogram computation
     * :attr:`axis` controls axis of spectrogram computation
     * :attr:`phase` holds the phase of the spectrogram
@@ -802,7 +802,7 @@ class Spectrogram(object):
     Args:
         window_size (int): size of STFT window in samples
         hop_size (int): size of STFT window hop in samples
-        n_fft(int, optional): number of frequency bins in STFT. If `None`,
+        fft_size(int, optional): number of frequency bins in STFT. If `None`,
             then it defaults to `window_size`. Default: `None`
         window (str, tuple, number, function, or numpy.ndarray, optional): type
             of STFT window. Default: `hann`
@@ -830,19 +830,19 @@ class Spectrogram(object):
 
     """
 
-    def __init__(self, window_size, hop_size, *, n_fft=None,
+    def __init__(self, window_size, hop_size, *, fft_size=None,
                  window='hann', axis=-1):
         super().__init__()
         self.window_size = window_size
         self.hop_size = hop_size
-        self.n_fft = n_fft
+        self.fft_size = fft_size
         self.window = window
         self.axis = axis
         self.phase = []
 
     def __call__(self, signal):
         spectrogram = F.stft(signal, self.window_size, self.hop_size,
-                             n_fft=self.n_fft, window=self.window,
+                             fft_size=self.fft_size, window=self.window,
                              axis=self.axis)
         magnitude, self.phase = librosa.magphase(spectrogram)
         return magnitude

--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -757,6 +757,7 @@ class Spectrogram(object):
 
     * :attr:`window_size` controls FFT window size in samples
     * :attr:`hop_size` controls STFT window hop size in samples
+    * :attr:`n_fft` controls number of frequency bins in STFT
     * :attr:`window` controls window function of spectrogram computation
     * :attr:`axis` controls axis of spectrogram computation
     * :attr:`phase` holds the phase of the spectrogram
@@ -764,6 +765,8 @@ class Spectrogram(object):
     Args:
         window_size (int): size of STFT window in samples
         hop_size (int): size of STFT window hop in samples
+        n_fft(int, optional): number of frequency bins in STFT. If `None`,
+            then it defaults to `window_size`. Default: `None`
         window (str, tuple, number, function, or numpy.ndarray, optional): type
             of STFT window. Default: `hann`
         axis (int, optional): axis of STFT calculation. Default: `-1`
@@ -790,17 +793,20 @@ class Spectrogram(object):
 
     """
 
-    def __init__(self, window_size, hop_size, *, window='hann', axis=-1):
+    def __init__(self, window_size, hop_size, *, n_fft=None,
+                 window='hann', axis=-1):
         super().__init__()
         self.window_size = window_size
         self.hop_size = hop_size
+        self.n_fft = n_fft
         self.window = window
         self.axis = axis
         self.phase = []
 
     def __call__(self, signal):
         spectrogram = F.stft(signal, self.window_size, self.hop_size,
-                             window=self.window, axis=self.axis)
+                             n_fft=self.n_fft, window=self.window,
+                             axis=self.axis)
         magnitude, self.phase = librosa.magphase(spectrogram)
         return magnitude
 

--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -687,9 +687,14 @@ class Standardize(object):
 
     Ensure the signal has a mean value of 0 and a variance of 1.
 
+    * :attr:`mean` controls whether mean centering will be applied
+    * :attr:`std` controls whether standard deviation normalization will be
+      applied
     * :attr:`axis` controls axis for standardization
 
     Args:
+        mean (bool, optional): apply mean centering. Default: `True`
+        std (bool, optional): normalize by standard deviation. Default: `True`
         axis (int, optional): standardize only along the given axis.
             Default: `-1`
 
@@ -701,21 +706,28 @@ class Standardize(object):
         >>> a = np.array([1, 2, 3, 4])
         >>> t = Standardize()
         >>> print(t)
-        Standardize(axis=-1)
+        Standardize(axis=-1, mean=True, std=True)
         >>> t(a)
         array([-1.34164079, -0.4472136 ,  0.4472136 ,  1.34164079])
 
     """
 
-    def __init__(self, axis=-1):
+    def __init__(self, *, mean=True, std=True, axis=-1):
         super().__init__()
         self.axis = axis
+        self.mean = mean
+        self.std = std
 
     def __call__(self, signal):
-        return F.standardize(signal, axis=self.axis)
+        return F.standardize(signal, axis=self.axis,
+                             mean=self.mean, std=self.std)
 
     def __repr__(self):
         options = 'axis={0}'.format(self.axis)
+        if self.mean:
+            options += ', mean=True'
+        if self.std:
+            options += ', std=True'
         return '{0}({1})'.format(self.__class__.__name__, options)
 
 

--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -682,6 +682,43 @@ class Normalize(object):
         return '{0}({1})'.format(self.__class__.__name__, options)
 
 
+class Standardize(object):
+    r"""Standardize signal.
+
+    Ensure the signal has a mean value of 0 and a variance of 1.
+
+    * :attr:`axis` controls axis for standardization
+
+    Args:
+        axis (int, optional): standardize only along the given axis.
+            Default: `-1`
+
+    Shape:
+        - Input: :math:`(*)`
+        - Output: :math:`(*)`, where :math:`*` can be any number of dimensions.
+
+    Example:
+        >>> a = np.array([1, 2, 3, 4])
+        >>> t = Standardize()
+        >>> print(t)
+        Standardize(axis=-1)
+        >>> t(a)
+        array([-1.34164079, -0.4472136 ,  0.4472136 ,  1.34164079])
+
+    """
+
+    def __init__(self, axis=-1):
+        super().__init__()
+        self.axis = axis
+
+    def __call__(self, signal):
+        return F.standardize(signal, axis=self.axis)
+
+    def __repr__(self):
+        options = 'axis={0}'.format(self.axis)
+        return '{0}({1})'.format(self.__class__.__name__, options)
+
+
 class Resample(object):
     """Resample to new sampling rate.
 

--- a/docs/api-transforms-functional.rst
+++ b/docs/api-transforms-functional.rst
@@ -47,6 +47,11 @@ normalize
 
 .. autofunction:: normalize
 
+standardize
+-----------
+
+.. autofunction:: standardize
+
 stft
 ----
 

--- a/docs/api-transforms.rst
+++ b/docs/api-transforms.rst
@@ -83,6 +83,12 @@ Normalize
 .. autoclass:: Normalize
     :members:
 
+Standardize
+-----------
+
+.. autoclass:: Standardize
+    :members:
+
 Resample
 --------
 

--- a/docs/api-transforms.rst
+++ b/docs/api-transforms.rst
@@ -95,6 +95,12 @@ Spectrogram
 .. autoclass:: Spectrogram
     :members:
 
+Log
+---
+
+.. autoclass:: Log
+    :members:
+
 LogSpectrogram
 --------------
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -140,6 +140,19 @@ def test_normalize(input, axis, expected_output):
     assert np.array_equal(t(input), expected_output)
 
 
+@pytest.mark.parametrize('input,axis', [
+    (A, None),
+    (A, -1),
+    (a11, None),
+    (a11, -1),
+])
+def test_standardize(input, axis):
+    t = transforms.Standardize(axis=axis)
+    output = t(input)
+    np.testing.assert_almost_equal(output.mean(axis=axis).mean(), 0)
+    np.testing.assert_almost_equal(output.std(axis=axis).mean(), 1)
+
+
 @pytest.mark.parametrize('input,idx,axis', [
     (A, (0, 2), -1),
     (a11, (1, 2), -1),

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -217,25 +217,36 @@ def test_resample(input, input_sample_rate, output_sample_rate, method, axis):
     assert np.array_equal(transformed_input, expected_output)
 
 
-@pytest.mark.parametrize('input,window_size,hop_size,axis,magnitude_boost', [
-    (A, 4, 1, 2, 1e-07),
-    pytest.param(A, 4, 1, 2, -1e-07, marks=xfail(raises=ValueError)),
-    pytest.param(A, 4, 1, 2, -1, marks=xfail(raises=ValueError)),
-    pytest.param(A, 2048, 1024, 2, 1e-07, marks=xfail(raises=ValueError)),
-    (np.random.normal(size=[2, 3, 16000]), 2048, 1024, 2, 1e-07),
-    (np.random.normal(size=[2, 16000, 3]), 2048, 1024, 1, 1e-07),
-    (np.random.normal(size=[16000, 2, 3]), 2048, 1024, 0, 1e-07),
-    (np.random.normal(size=[16000, 2, 3]), 2048, 1024, 0, 0),
-    (np.random.normal(size=16000), 2048, 1024, 0, 1e-07),
+@pytest.mark.parametrize('input,window_size,hop_size,axis', [
+    (A, 4, 1, 2),
+    pytest.param(A, 2048, 1024, 2, marks=xfail(raises=ValueError)),
+    (np.random.normal(size=[2, 3, 16000]), 2048, 1024, 2),
+    (np.random.normal(size=[2, 16000, 3]), 2048, 1024, 1),
+    (np.random.normal(size=[16000, 2, 3]), 2048, 1024, 0),
+    (np.random.normal(size=[16000, 2, 3]), 2048, 1024, 0),
+    (np.random.normal(size=16000), 2048, 1024, 0),
 ])
-def test_stft(input, window_size, hop_size, axis, magnitude_boost):
+def test_stft(input, window_size, hop_size, axis):
     t = transforms.Spectrogram(window_size, hop_size, axis=axis)
-    t_log = transforms.Log(magnitude_boost=magnitude_boost)
     spectrogram = F.stft(input, window_size, hop_size, axis=axis)
     magnitude, phase = librosa.magphase(spectrogram)
     assert np.array_equal(t(input), magnitude)
-    assert np.array_equal(t_log(t(input)), np.log(magnitude + magnitude_boost))
     assert np.array_equal(t.phase, phase)
+
+
+@pytest.mark.parametrize('input,magnitude_boost', [
+    (A, 1e-07),
+    pytest.param(A, -1e-07, marks=xfail(raises=ValueError)),
+    pytest.param(A, -1, marks=xfail(raises=ValueError)),
+    (np.random.normal(size=[2, 3, 16000]), 1e-03),
+    (np.random.normal(size=[2, 16000, 3]), 1e-07),
+    (np.random.normal(size=[16000, 2, 3]), 1e-07),
+    (np.random.normal(size=16000), 1e-07),
+])
+def test_log(input, magnitude_boost):
+    input = input + abs(input.min())
+    t_log = transforms.Log(magnitude_boost=magnitude_boost)
+    assert np.array_equal(t_log(input), np.log(input + magnitude_boost))
 
 
 @pytest.mark.parametrize('signal1,signal2,ratio,'

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -207,23 +207,22 @@ def test_resample(input, input_sample_rate, output_sample_rate, method, axis):
 @pytest.mark.parametrize('input,window_size,hop_size,axis,magnitude_boost', [
     (A, 4, 1, 2, 1e-07),
     pytest.param(A, 4, 1, 2, -1e-07, marks=xfail(raises=ValueError)),
-    pytest.param(A, 4, 1, 2, 0, marks=xfail(raises=ValueError)),
+    pytest.param(A, 4, 1, 2, -1, marks=xfail(raises=ValueError)),
     pytest.param(A, 2048, 1024, 2, 1e-07, marks=xfail(raises=ValueError)),
     (np.random.normal(size=[2, 3, 16000]), 2048, 1024, 2, 1e-07),
     (np.random.normal(size=[2, 16000, 3]), 2048, 1024, 1, 1e-07),
     (np.random.normal(size=[16000, 2, 3]), 2048, 1024, 0, 1e-07),
+    (np.random.normal(size=[16000, 2, 3]), 2048, 1024, 0, 0),
     (np.random.normal(size=16000), 2048, 1024, 0, 1e-07),
 ])
 def test_stft(input, window_size, hop_size, axis, magnitude_boost):
     t = transforms.Spectrogram(window_size, hop_size, axis=axis)
-    t_log = transforms.LogSpectrogram(window_size, hop_size, axis=axis,
-                                      magnitude_boost=magnitude_boost)
+    t_log = transforms.Log(magnitude_boost=magnitude_boost)
     spectrogram = F.stft(input, window_size, hop_size, axis=axis)
     magnitude, phase = librosa.magphase(spectrogram)
     assert np.array_equal(t(input), magnitude)
-    assert np.array_equal(t_log(input), np.log(magnitude + magnitude_boost))
+    assert np.array_equal(t_log(t(input)), np.log(magnitude + magnitude_boost))
     assert np.array_equal(t.phase, phase)
-    assert np.array_equal(t_log.phase, phase)
 
 
 @pytest.mark.parametrize('signal1,signal2,ratio,'

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -140,17 +140,22 @@ def test_normalize(input, axis, expected_output):
     assert np.array_equal(t(input), expected_output)
 
 
-@pytest.mark.parametrize('input,axis', [
-    (A, None),
-    (A, -1),
-    (a11, None),
-    (a11, -1),
+@pytest.mark.parametrize('input,axis,mean,std', [
+    (A, None, True, True),
+    (A, -1, True, True),
+    (a11, None, True, True),
+    (a11, -1, True, True),
+    (A, -1, False, True),
+    (A, -1, True, False),
+    (A, -1, False, False),
 ])
-def test_standardize(input, axis):
+def test_standardize(input, axis, mean, std):
     t = transforms.Standardize(axis=axis)
     output = t(input)
-    np.testing.assert_almost_equal(output.mean(axis=axis).mean(), 0)
-    np.testing.assert_almost_equal(output.std(axis=axis).mean(), 1)
+    if mean:
+        np.testing.assert_almost_equal(output.mean(axis=axis).mean(), 0)
+    if std:
+        np.testing.assert_almost_equal(output.std(axis=axis).mean(), 1)
 
 
 @pytest.mark.parametrize('input,idx,axis', [

--- a/tests/test_transforms_functional.py
+++ b/tests/test_transforms_functional.py
@@ -123,6 +123,18 @@ def test_normalize(input, axis, expected_output):
     assert np.array_equal(output, expected_output)
 
 
+@pytest.mark.parametrize('input,axis', [
+    (A, None),
+    (A, -1),
+    (a11, None),
+    (a11, -1),
+])
+def test_standardize(input, axis):
+    output = F.standardize(input, axis=axis)
+    np.testing.assert_almost_equal(output.mean(axis=axis).mean(), 0)
+    np.testing.assert_almost_equal(output.std(axis=axis).mean(), 1)
+
+
 @pytest.mark.parametrize('input,window_size,hop_size,axis', [
     (A, 4, 1, 2),
     pytest.param(A, 2048, 1024, 2, marks=xfail(raises=ValueError)),

--- a/tests/test_transforms_functional.py
+++ b/tests/test_transforms_functional.py
@@ -123,16 +123,21 @@ def test_normalize(input, axis, expected_output):
     assert np.array_equal(output, expected_output)
 
 
-@pytest.mark.parametrize('input,axis', [
-    (A, None),
-    (A, -1),
-    (a11, None),
-    (a11, -1),
+@pytest.mark.parametrize('input,axis,mean,std', [
+    (A, None, True, True),
+    (A, -1, True, True),
+    (a11, None, True, True),
+    (a11, -1, True, True),
+    (A, -1, False, True),
+    (A, -1, True, False),
+    (A, -1, False, False),
 ])
-def test_standardize(input, axis):
-    output = F.standardize(input, axis=axis)
-    np.testing.assert_almost_equal(output.mean(axis=axis).mean(), 0)
-    np.testing.assert_almost_equal(output.std(axis=axis).mean(), 1)
+def test_standardize(input, axis, mean, std):
+    output = F.standardize(input, axis=axis, mean=mean, std=std)
+    if mean:
+        np.testing.assert_almost_equal(output.mean(axis=axis).mean(), 0)
+    if std:
+        np.testing.assert_almost_equal(output.std(axis=axis).mean(), 1)
 
 
 @pytest.mark.parametrize('input,window_size,hop_size,axis', [


### PR DESCRIPTION
### Summary

Tidy up and extend our existing Spectrogram transforms.

### Proposed Changes

* Add `n_fft` parameter to `stft` functional and `Spectrogram` transform to allow the user to optionally use a different window size than FFT size

* Add `Log` transforms that allows for `magnitude_boost` as well

* Add `standardize` functional and `Standardize` transform that take care of mean and std normalizing a signal, either globally or across an axis.

* Schedule `LogSpectrogram` transform for deprecation as it does not add any extra functionality.
### Discussion

Only if needed:

1. Should I remove `LogSpectrogram` now or should we do it in a later version
2. Should I allow the `Standardize` transform to only do mean-normalization or std-normalization based on some user options? e.g. `mean=True`, `std=True`?