### PR TITLE
DOC: remove broken logos from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F41B Bug Report"
+name: "Bug Report"
 about: Submit a bug report to help us improve audtorch
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F4DA Documentation"
+name: "Documentation"
 about: Report an issue related to https://audtorch.readthedocs.io/
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F680Feature Request"
+name: "Feature Request"
 about: Submit a proposal/request for a new audtorch feature
 
 ---

--- a/.github/ISSUE_TEMPLATE/questions-help-support.md
+++ b/.github/ISSUE_TEMPLATE/questions-help-support.md
@@ -1,5 +1,5 @@
 ---
-name: "❓Questions/Help/Support"
+name: "Questions/Help/Support"
 about: Do you need support? We have resources.
 
 ---


### PR DESCRIPTION
### Summary

The icons in the headings of our issue templates are broken. This pull request just removes the icons and introduces text only headings which should be sufficient.