### PR TITLE
Fix archive extraction for LibriSpeech

### DIFF
--- a/audtorch/datasets/libri_speech.py
+++ b/audtorch/datasets/libri_speech.py
@@ -144,7 +144,7 @@ class LibriSpeech(PandasDataset):
         urls = [self.urls[s] for s in absent_sets]
         filenames = download_url_list(urls, out_path, num_workers=0)
         for filename in filenames:
-            extract_archive(os.path.join(out_path, filename),
+            extract_archive(filename,
                             out_path=out_path,
                             remove_finished=True)
         os.system('mv {} {}'.format(os.path.join(out_path, 'LibriSpeech/*'),


### PR DESCRIPTION
### Summary

This closes #30.
It seems to be that the bug was directly part of the `LibriSpeech` code and we can fix it there.


### Proposed Changes

The `filenames` returned by `download_url_list` conatin already the complete path and can directly be passed on to `extract_archive`. I changed the code accordingly.