### PR TITLE
Add safe_path to ensure absolute paths

### DIFF
--- a/audtorch/datasets/audio_set.py
+++ b/audtorch/datasets/audio_set.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from ..utils import flatten_list
 from .base import AudioDataset
+from .utils import safe_path
 
 
 __doctest_skip__ = ['*']
@@ -133,7 +134,7 @@ class AudioSet(AudioDataset):
     def __init__(self, root, csv_file='balanced_train_segments.csv',
                  sampling_rate=16000, include=None, exclude=None,
                  transform=None, target_transform=None):
-        root = os.path.expanduser(root)
+        root = safe_path(root)
         # Allow only official CSV files as no audio paths are defined otherwise
         assert csv_file in ['eval_segments.csv', 'balanced_train_segments.csv',
                             'unbalanced_train_segments.csv']

--- a/audtorch/datasets/base.py
+++ b/audtorch/datasets/base.py
@@ -7,7 +7,7 @@ from tabulate import tabulate
 from torch.utils.data import (Dataset, ConcatDataset)
 
 from .utils import (ensure_same_sampling_rate, files_and_labels_from_df,
-                    load, sampling_rate_after_transform)
+                    load, sampling_rate_after_transform, safe_path)
 
 
 __doctest_skip__ = ['*']
@@ -58,7 +58,7 @@ class AudioDataset(Dataset):
 
     def __init__(self, root, files, targets, sampling_rate, *, transform=None,
                  target_transform=None):
-        self.root = os.path.expanduser(root)
+        self.root = safe_path(root)
         self.files = [os.path.join(self.root, f) for f in files]
         self.targets = targets
         self.original_sampling_rate = sampling_rate
@@ -268,7 +268,7 @@ class CsvDataset(PandasDataset):
     def __init__(self, root, csv_file, sampling_rate, *, sep=',',
                  column_labels='label', column_filename='filename',
                  transform=None, target_transform=None):
-        self.root = os.path.expanduser(root)
+        self.root = safe_path(root)
         self.csv_file = os.path.join(self.root, csv_file)
 
         if not os.path.isfile(self.csv_file):

--- a/audtorch/datasets/libri_speech.py
+++ b/audtorch/datasets/libri_speech.py
@@ -2,7 +2,7 @@ import os
 import glob
 import pandas as pd
 
-from .utils import (download_url_list, extract_archive)
+from .utils import (download_url_list, extract_archive, safe_path)
 from ..utils import run_worker_threads
 from .base import PandasDataset
 
@@ -94,7 +94,7 @@ class LibriSpeech(PandasDataset):
     def __init__(self, root, *, sets=None, dataframe=None,
                  transform=None, target_transform=None, download=False):
 
-        self.root = os.path.expanduser(root)
+        self.root = safe_path(root)
 
         if isinstance(sets, str):
             sets = [sets]

--- a/audtorch/datasets/mozilla_common_voice.py
+++ b/audtorch/datasets/mozilla_common_voice.py
@@ -1,6 +1,6 @@
 import os
 
-from .utils import (download_url, extract_archive)
+from .utils import (download_url, extract_archive, safe_path)
 from .base import CsvDataset
 
 
@@ -82,7 +82,7 @@ class MozillaCommonVoice(CsvDataset):
                  download=False):
 
         if download:
-            self.root = os.path.expanduser(root)
+            self.root = safe_path(root)
             self._download()
 
         super().__init__(root, csv_file, sampling_rate=48000, sep=',',

--- a/audtorch/datasets/utils.py
+++ b/audtorch/datasets/utils.py
@@ -73,7 +73,7 @@ def download_url(url, root, *, filename=None, md5=None):
        str: path to downloaded file
 
     """
-    root = os.path.expanduser(root)
+    root = safe_path(root)
     if not filename:
         filename = os.path.basename(url)
     filename = os.path.join(root, filename)
@@ -93,7 +93,7 @@ def download_url(url, root, *, filename=None, md5=None):
                       ' Downloading ' + url + ' to ' + filename)
                 urllib.request.urlretrieve(url, filename,
                                            reporthook=bar_updater)
-    return os.path.expanduser(filename)
+    return safe_path(filename)
 
 
 def download_url_list(urls, root, *, num_workers=0):
@@ -286,7 +286,7 @@ def files_and_labels_from_df(df, *, root='.', column_labels='label',
     """
     if df is None:
         return [], []
-    root = os.path.expanduser(root)
+    root = safe_path(root)
     if isinstance(column_labels, str):
         column_labels = [column_labels]
     ensure_df_columns_contain(df, column_labels)
@@ -354,3 +354,8 @@ def defined_split(dataset, split_func):
 
     return [Subset(dataset, indices)
             for indices in split_indices]
+
+
+def safe_path(path):
+    """Ensure the path is absolute and doesn't include `..` or `~`."""
+    return os.path.abspath(os.path.expanduser(path))

--- a/audtorch/datasets/utils.py
+++ b/audtorch/datasets/utils.py
@@ -280,8 +280,8 @@ def files_and_labels_from_df(df, *, root='.', column_labels='label',
         >>> df = pd.DataFrame(data=[('speech.wav', 'speech')],
         ...                   columns=['filename', 'label'])
         >>> files, labels = files_and_labels_from_df(df)
-        >>> files[0], labels[0]
-        ('./speech.wav', 'speech')
+        >>> os.path.relpath(files[0]), labels[0]
+        ('speech.wav', 'speech')
 
     """
     if df is None:

--- a/audtorch/datasets/utils.py
+++ b/audtorch/datasets/utils.py
@@ -357,5 +357,13 @@ def defined_split(dataset, split_func):
 
 
 def safe_path(path):
-    """Ensure the path is absolute and doesn't include `..` or `~`."""
+    """Ensure the path is absolute and doesn't include `..` or `~`.
+
+    Args:
+        path (str): absolute or relative path
+
+    Returns:
+        str: absolute path
+
+    """
     return os.path.abspath(os.path.expanduser(path))

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -118,6 +118,7 @@ def test_files_and_labels_from_df(df, expected_files, expected_labels):
                                                       root='.',
                                                       column_filename='a',
                                                       column_labels='b')
+    expected_files = [datasets.safe_path(f) for f in expected_files]
     assert files == expected_files
     assert labels == expected_labels
 


### PR DESCRIPTION
### Summary

Fix path handling in data sets.
As discussed in #32 we have errors when providing a relative path to our data sets as internally we used only `os.path.expanduser` which handles paths like `~/tmp`, but not `./tmp`.


### Proposed Changes

* Add the function `safe_path` to `audtorch.datasets.utils`.
* Change all occurrences of `os.path.expanduser` in the data sets to `safe_path`


### Discussion

1. The naming of `safe_path` is maybe not optimal.
2. Unit tests are missing
3. There might also be a better way to deal with the underlying issue as in some cases we actual would like to have relative paths (as maybe in the functions for which this PR fails the tests)