### PR TITLE
DOC: Switch to changelog format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,29 @@
+Changelog
+=========
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog`_,
+and this project adheres to `Semantic Versioning`_.
+
+Version 0.1.1 (2019-05-23)
+--------------------------
+
+Fixed
+~~~~~
+
+* Broken API documentation on RTD_
+
+
+Version 0.1.0 (2019-05-22)
+--------------------------
+
+Added
+~~~~~
+
+* Public release
+
+
+.. _Keep a Changelog: https://keepachangelog.com/en/1.0.0/
+.. _Semantic Versioning: https://semver.org/spec/v2.0.0.html
+.. _RTD: https://audtorch.readthedocs.io/

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,8 +1,0 @@
-Version History
-===============
-
-Version 0.1.1 (2019-05-23):
- * Fix broken API documentation on RTD
-
-Version 0.1.0 (2019-05-22):
- * Public release

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGELOG.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@
     install
     usage
     develop
-    version-history
+    changelog
 
 .. Warning: then usage of genindex is a hack to get a TOC entry, see
 .. https://stackoverflow.com/a/42310803. This might break the usage of sphinx if

--- a/docs/version-history.rst
+++ b/docs/version-history.rst
@@ -1,1 +1,0 @@
-.. include:: ../NEWS.rst


### PR DESCRIPTION
### Summary

Just updated to the Changelog format of https://keepachangelog.com/en/1.0.0/.


### Proposed Changes

Rename `NEWS.rst` to `CHANGELOG.rst` and change the heading `Version History` in the docs to `Changelog`.
