### PR TITLE
Add documentation and tracker URLs to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,10 @@ setup(
     license='MIT License',
     keywords=['audio'],
     url='https://github.com/audeering/audtorch',
+    project_urls={
+        'Documentation': 'https://audtorch.readthedocs.io',
+        'Tracker': 'https://github.com/audeering/audtorch/issues',
+    },
     platforms='any',
     tests_require=['pytest'],
     classifiers=[


### PR DESCRIPTION
### Summary

Add links to our documentation and issue tracker to `setup.py`. Those will then appear as nice extra links [our pypi.org page](https://pypi.org/project/audtorch/), compare the [pypi page of Django](https://pypi.org/project/Django/)


### Proposed Changes

Added `project_urls` to `setup.py`