### PR TITLE
TST: reduce RAM usage of test_samplers

### DIFF
--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -14,8 +14,8 @@ from audtorch.datasets.utils import defined_split
 # data sets
 data_size = 1000
 num_feats = 160
-max_length = 3000
-max_feature = 1000
+max_length = 300
+max_feature = 100
 lengths = torch.randint(0, max_length, (data_size,))
 inputs = torch.randint(0, max_feature, (data_size, num_feats, max_length))
 data = TensorDataset(inputs)


### PR DESCRIPTION
### Summary

In #33 one test on travis failed due to shortage of RAM. This fixes it by reducing the amount of RAM needed by around 3GB.


### Proposed Changes

Factor 10 smaller `max_length` and `max_feature` in `test/test_sampler.py`


### Discussion

1. @shuber: does the test still makes sense with the smaller numbers?
