### PR TITLE
DOC: simplify virtualenv example

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,7 +19,7 @@ newest development version from Github_::
    git clone https://github.com/audeering/audtorch/
    cd audtorch
    # Create virtual environment, e.g.
-   # virtualenv --python=/usr/bin/python3 --no-site-packages _env
+   # virtualenv --python=python3 _env
    # source _env/bin/activate
    python setup.py develop
 


### PR DESCRIPTION
### Summary

Simplify example call to `virtualenv` as `--no-site-packages` is no longer needed and `python3` is sufficient (and we cannot expect that `/usr/bin/python3` exists on all systems).