### PR TITLE
Added Google Speech Commands V2 Dataset

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -9,6 +9,7 @@ Authors:
     Hagen Wierstorf
 
 Contributors:
+    Harri Taylor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/audtorch/datasets/__init__.py
+++ b/audtorch/datasets/__init__.py
@@ -3,6 +3,7 @@ from .base import *
 from .libri_speech import *
 from .mixture import *
 from .mozilla_common_voice import *
+from .speech_commands import *
 from .voxceleb1 import *
 from .white_noise import *
 from .utils import *

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -64,27 +64,27 @@ class SpeechCommands(AudioDataset):
     def __init__(self, root, train=True, download=False, *,
                  sampling_rate=16000, include=None, silence=True,
                  transform=None, target_transform=None):
+        self.root = safe_path(root)
 
         if download:
-            self.root = safe_path(root)
             self._download()
 
         if include is None:
             include = self.commands
 
-        with open(safe_path(os.path.join(root, 'testing_list.txt'))) as f:
+        with open(safe_path(os.path.join(self.root, 'testing_list.txt'))) as f:
             test_files = f.read().splitlines()
 
         files, targets = [], []
         for speech_cmd in self.commands:
-            d = os.listdir(os.path.join(root, speech_cmd))
+            d = os.listdir(os.path.join(self.root, speech_cmd))
             d = [os.path.join(speech_cmd, x) for x in d]
 
             # Filter out test / train files using `testing_list.txt`
             d_f = list(set(d) - set(test_files)) \
                 if train else list(set(d) & set(test_files))
 
-            files.extend([os.path.join(root, p) for p in d_f])
+            files.extend([os.path.join(self.root, p) for p in d_f])
             target = speech_cmd if speech_cmd in include else 'unknown'
             targets.extend([target for _ in range(len(d_f))])
 
@@ -95,9 +95,9 @@ class SpeechCommands(AudioDataset):
                 if train else int(n_samples * 0.1)
 
             sf = []
-            for file in os.listdir(os.path.join(root, '_background_noise_')):
+            for file in os.listdir(os.path.join(self.root, '_background_noise_')):
                 if file.endswith('.wav'):
-                    sf.append(os.path.join(root, '_background_noise_', file))
+                    sf.append(os.path.join(self.root, '_background_noise_', file))
 
             targets.extend(['silence' for _ in range(n_samples)])
             files.extend(random.choices(sf, k=n_samples))
@@ -114,4 +114,4 @@ class SpeechCommands(AudioDataset):
         if download_dir.endswith(corpus):
             download_dir = download_dir[:-len(corpus)]
         filename = download_url(self.url, download_dir)
-        extract_archive(filename, remove_finished=True)
+        extract_archive(filename, out_path=self.root, remove_finished=True)

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -3,7 +3,8 @@ import random
 
 from .utils import (download_url, extract_archive, safe_path)
 from .base import AudioDataset
-from .utils import safe_path
+
+__doctest_skip__ = ['*']
 
 
 class SpeechCommands(AudioDataset):

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -23,10 +23,11 @@ class SpeechCommands(AudioDataset):
         download (bool, optional): Download the dataset to `root` if it's not
             already available. Default: False
         include (list of str, optional): list of categories to include as
-            commands. If `None` all categories are included. Default: `['yes',
-            'no', 'up', 'down', 'left', 'right', 'on', 'off', 'stop', 'go']`.
+            commands. If `None` all categories are included. Default:
+            `['yes','no','up','down','left','right','on','off','stop','go']`
         silence (bool, optional): include a 'silence' class composed of
-            background noise. (Note: use randomcrop when training) Default: `True`
+            background noise. (Note: use randomcrop when training)
+            Default: `True`
         transform (callable, optional): function/transform applied on the
             signal. Default: `None`
         target_transform (callable, optional): function/transform applied on
@@ -34,7 +35,7 @@ class SpeechCommands(AudioDataset):
 
     Example:
         >>> import sounddevice as sd
-        >>> data = SpeechCommands(root='/data/speech_commands_v0.02', train=True)
+        >>> data = SpeechCommands(root='/data/speech_commands_v0.02')
         >>> print(data)
         Dataset SpeechCommands
             Number of data points: 97524
@@ -60,8 +61,9 @@ class SpeechCommands(AudioDataset):
 
     background_noise = '_background_noise_'
 
-    def __init__(self, root, train=True, download=False, *, sampling_rate=16000,
-                 include=None, silence=True, transform=None, target_transform=None):
+    def __init__(self, root, train=True, download=False, *,
+                 sampling_rate=16000, include=None, silence=True,
+                 transform=None, target_transform=None):
 
         if download:
             self.root = safe_path(root)
@@ -79,7 +81,8 @@ class SpeechCommands(AudioDataset):
             d = [os.path.join(speech_cmd, x) for x in d]
 
             # Filter out test / train files using `testing_list.txt`
-            d_f = list(set(d) - set(test_files)) if train else list(set(d) & set(test_files))
+            d_f = list(set(d) - set(test_files)) \
+                if train else list(set(d) & set(test_files))
 
             files.extend([os.path.join(root, p) for p in d_f])
             target = speech_cmd if speech_cmd in include else 'unknown'
@@ -88,17 +91,20 @@ class SpeechCommands(AudioDataset):
         # Match occurrences of silence with `unknown`
         if silence:
             n_samples = max(targets.count('unknown'), 3_000)
-            n_samples = int(n_samples * 0.9) if train else int(n_samples * 0.1)
+            n_samples = int(n_samples * 0.9) \
+                if train else int(n_samples * 0.1)
 
-            sfiles = []
+            sf = []
             for file in os.listdir(os.path.join(root, '_background_noise_')):
                 if file.endswith('.wav'):
-                    sfiles.append(os.path.join(root, '_background_noise_', file))
+                    sf.append(os.path.join(root, '_background_noise_', file))
 
             targets.extend(['silence' for _ in range(n_samples)])
-            files.extend(random.choices(sfiles, k=n_samples))
+            files.extend(random.choices(sf, k=n_samples))
 
-        super().__init__(root, files, targets, sampling_rate, transform=transform, target_transform=target_transform)
+        super().__init__(root, files, targets, sampling_rate,
+                         transform=transform,
+                         target_transform=target_transform)
 
     def _download(self):
         if self._check_exists():

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -1,0 +1,85 @@
+import os
+import random
+
+from .utils import (download_url, extract_archive, safe_path)
+from .base import AudioDataset
+from .utils import safe_path
+
+
+class SpeechCommands(AudioDataset):
+    """
+
+    Google Speech Commands V2
+
+    Args:
+        root (str): root directory of data set, where the CSV files are
+            located, e.g. `/data/speech_commands_v0.02`
+        train (bool, optional): Return the training split. `False` returns the
+            test split. Default: True
+        download (bool, optional): Download the dataset to `root` if it's not
+            already available. Default: False (TODO)
+        sampling_rate (int, optional):
+        include (list of str, optional): list of categories to include as
+            commands.
+            If `None` all categories are included. Default:
+            `['yes', 'no', 'up', 'down', 'left', 'right', 'on', 'off', 'stop', 'go']`
+        silence (bool, optional): include a 'silence' class composed of background noise.
+            Default: `True`
+        transform (callable, optional): function/transform applied on the
+            signal. Default: `None`
+        target_transform (callable, optional): function/transform applied on
+            the target. Default: `None`
+    """
+
+    # Available target commands
+    commands = [
+        'right', 'eight', 'cat', 'tree', 'backward',
+        'learn', 'bed', 'happy', 'go', 'dog', 'no',
+        'wow', 'follow', 'nine', 'left', 'stop', 'three',
+        'sheila', 'one', 'bird', 'zero', 'seven', 'up',
+        'visual', 'marvin', 'two', 'house', 'down', 'six',
+        'yes', 'on', 'five', 'forward', 'off', 'four']
+
+    background_noise = '_background_noise_'
+
+    def __init__(self, root, train=True, download=False, *, sampling_rate=16000,
+                 include=None, silence=True, transform=None, target_transform=None):
+
+        if download:
+            self._download()
+
+        if include is None:
+            include = self.commands
+
+        with open(safe_path(os.path.join(root, 'testing_list.txt'))) as f:
+            test_files = f.read().splitlines()
+
+        files, targets = [], []
+        for speech_cmd in self.commands:
+            d = os.listdir(os.path.join(root, speech_cmd))
+            d = [os.path.join(speech_cmd, x) for x in d]
+
+            # Filter out test / train files using `testing_list.txt`
+            d_f = list(set(d) - set(test_files)) if train else list(set(d) & set(test_files))
+
+            files.extend([os.path.join(root, p) for p in d_f])
+            target = speech_cmd if speech_cmd in include else 'unknown'
+            targets.extend([target for _ in range(len(d_f))])
+
+        # Match occurrences of silence with `unknown`
+        if silence:
+            n_samples = max(targets.count('unknown'), 3_000)
+            n_samples = int(n_samples * 0.9) if train else int(n_samples * 0.1)
+
+            sfiles = []
+            for file in os.listdir(os.path.join(root, '_background_noise_')):
+                if file.endswith('.wav'):
+                    sfiles.append(os.path.join(root, '_background_noise_', file))
+
+            targets.extend(['silence' for _ in range(n_samples)])
+            files.extend(random.choices(sfiles,k=n_samples))
+
+        super().__init__(root, files, targets, sampling_rate, transform=transform, target_transform=target_transform)
+
+    def _download(self):
+        return NotImplementedError("TODO: Automatically download dataset to root dir")

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -26,10 +26,10 @@ class SpeechCommands(AudioDataset):
             `False` returns the test split. Default: False.
         download (bool, optional): Download the dataset to `root` if it's not
             already available. Default: False
-        include (str, or list of str): list of commands to include as recognised
-            words. options: `"10cmd"`, `"full"`. A custom dataset can be defined
-            using a list of command words. For example, ["stop","go"]. Words that
-            are not in the "include" list are treated as unknown words.
+        include (str, or list of str): commands to include as 'recognised'
+        words. options: `"10cmd"`, `"full"`. A custom dataset can be defined
+            using a list of command words. For example, ["stop","go"]. Words
+             that are not in the "include" list are treated as unknown words.
         silence (bool, optional): include a 'silence' class composed of
             background noise. (Note: use randomcrop when training)
             Default: `True`
@@ -68,7 +68,7 @@ class SpeechCommands(AudioDataset):
         # https://arxiv.org/pdf/1710.06554.pdf
         '10cmd': ['yes', 'no', 'up', 'down', 'left',
                   'right', 'on', 'off', 'stop', 'go'],
-        'full':  classes
+        'full': classes
     }
 
     def __init__(self, root, train=True, download=False, *,

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -19,15 +19,12 @@ class SpeechCommands(AudioDataset):
         root (str): root directory of data set, where the CSV files are
             located, e.g. `/data/speech_commands_v0.02`
         train (bool, optional): Partition the dataset into the training set.
-        `False` returns the test split. Default: True
+            `False` returns the test split. Default: False.
         download (bool, optional): Download the dataset to `root` if it's not
             already available. Default: False
-        sampling_rate (int, optional):
         include (list of str, optional): list of categories to include as
-            commands.
-            If `None` all categories are included. Default:
-            `['yes', 'no', 'up', 'down', 'left', 'right', 'on', 'off',
-            'stop', 'go']`
+            commands. If `None` all categories are included. Default: `['yes',
+            'no', 'up', 'down', 'left', 'right', 'on', 'off', 'stop', 'go']`.
         silence (bool, optional): include a 'silence' class composed of
             background noise. (Note: use randomcrop when training) Default: `True`
         transform (callable, optional): function/transform applied on the
@@ -47,7 +44,6 @@ class SpeechCommands(AudioDataset):
         >>> target
         'right'
         >>> sd.play(signal.transpose(), data.sampling_rate)
-
     """
 
     url = ('http://download.tensorflow.org/'

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -77,6 +77,7 @@ class SpeechCommands(AudioDataset):
         self.root = safe_path(root)
         self.same_length = False
         self.silence_label = -1
+        self.trim = RandomCrop(sampling_rate)
 
         if download:
             self._download()
@@ -154,8 +155,7 @@ class SpeechCommands(AudioDataset):
 
         # https://github.com/audeering/audtorch/pull/49#discussion_r319044362
         if target == self.silence_label and self.same_length:
-            trim = RandomCrop(self.sampling_rate)
-            signal = trim(signal)
+            signal = self.trim(signal)
 
         if self.transform is not None:
             signal = self.transform(signal)

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -8,8 +8,7 @@ __doctest_skip__ = ['*']
 
 
 class SpeechCommands(AudioDataset):
-    r"""An audio dataset of spoken words designed to help train and evaluate
-    keyword spotting systems
+    r"""Data set of spoken words designed for keyword spotting tasks.
 
     Speech Commands V2 publicly available from Google:
     http://download.tensorflow.org/data/speech_commands_v0.02.tar.gz

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -90,7 +90,7 @@ class SpeechCommands(AudioDataset):
 
         # Match occurrences of silence with `unknown`
         if silence:
-            n_samples = max(targets.count('unknown'), 3_000)
+            n_samples = max(targets.count('unknown'), 3000)
             n_samples = int(n_samples * 0.9) \
                 if train else int(n_samples * 0.1)
 

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -3,6 +3,7 @@ import random
 
 from .utils import (download_url, extract_archive, safe_path)
 from .base import AudioDataset
+from os.path import join
 
 __doctest_skip__ = ['*']
 
@@ -72,19 +73,19 @@ class SpeechCommands(AudioDataset):
         if include is None:
             include = self.commands
 
-        with open(safe_path(os.path.join(self.root, 'testing_list.txt'))) as f:
+        with open(safe_path(join(self.root, 'testing_list.txt'))) as f:
             test_files = f.read().splitlines()
 
         files, targets = [], []
         for speech_cmd in self.commands:
-            d = os.listdir(os.path.join(self.root, speech_cmd))
-            d = [os.path.join(speech_cmd, x) for x in d]
+            d = os.listdir(join(self.root, speech_cmd))
+            d = [join(speech_cmd, x) for x in d]
 
             # Filter out test / train files using `testing_list.txt`
             d_f = list(set(d) - set(test_files)) \
                 if train else list(set(d) & set(test_files))
 
-            files.extend([os.path.join(self.root, p) for p in d_f])
+            files.extend([join(self.root, p) for p in d_f])
             target = speech_cmd if speech_cmd in include else 'unknown'
             targets.extend([target for _ in range(len(d_f))])
 
@@ -95,9 +96,9 @@ class SpeechCommands(AudioDataset):
                 if train else int(n_samples * 0.1)
 
             sf = []
-            for file in os.listdir(os.path.join(self.root, '_background_noise_')):
+            for file in os.listdir(join(self.root, '_background_noise_')):
                 if file.endswith('.wav'):
-                    sf.append(os.path.join(self.root, '_background_noise_', file))
+                    sf.append(join(self.root, '_background_noise_', file))
 
             targets.extend(['silence' for _ in range(n_samples)])
             files.extend(random.choices(sf, k=n_samples))


### PR DESCRIPTION
### Summary

As title, added google speech commands dataset, with some choice designs for preprocessing as described in the next section.

### Proposed Changes

- Added speech commands dataset
- Dataset partitioning into train / test using `testing_list.txt` from the dataset download
    - `validation_list.txt` is still provided for use to use `sampler` in the dataloader if train/valid/test is desired
- Using `include` keyword for defining custom subset of dataset. All other words in the dataset are marked as `unknown` (not sure if this adheres to the original split, but couldn't find more information about this)
- Using `silence` keyword to include samples from `_background_noise_` folder

### Discussion

1. `silence`: currently the DataSet simply points to samples in the `_background_noise_` folder. These samples are 1min long, whereas the speech commands are 1sec long. My current workaround is to use RandomCrop with 16,000 samples, which deals with this issue nicely. I don't think it would be efficient to chop up and store up 1 second clips of the `silence` clips.
