### PR TITLE
DOC: include SpeechCommands and clean up of index

### DIFF
--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -20,23 +20,32 @@ class SpeechCommands(AudioDataset):
     License: CC BY 4.0
 
     Args:
-        root (str): root directory of data set, where the CSV files are
-            located, e.g. `/data/speech_commands_v0.02`
+        root (str): root directory of data set,
+            where the CSV files are located,
+            e.g. `/data/speech_commands_v0.02`
         train (bool, optional): Partition the dataset into the training set.
-            `False` returns the test split. Default: False.
-        download (bool, optional): Download the dataset to `root` if it's not
-            already available. Default: False
-        include (str, or list of str): commands to include as 'recognised'
-        words. options: `"10cmd"`, `"full"`. A custom dataset can be defined
-            using a list of command words. For example, ["stop","go"]. Words
-             that are not in the "include" list are treated as unknown words.
+            `False` returns the test split.
+            Default: `False`
+        download (bool, optional): Download the dataset to `root`
+            if it's not already available.
+            Default: `False`
+        include (str, or list of str, optional): commands to include
+            as 'recognised' words.
+            Options: `"10cmd"`, `"full"`.
+            A custom dataset can be defined using a list of command words.
+            For example, `["stop","go"]`.
+            Words that are not in the "include" list
+            are treated as unknown words.
+            Default: `'10cmd'`
         silence (bool, optional): include a 'silence' class composed of
-            background noise. (Note: use randomcrop when training)
+            background noise (Note: use randomcrop when training).
             Default: `True`
         transform (callable, optional): function/transform applied on the
-            signal. Default: `None`
+            signal.
+            Default: `None`
         target_transform (callable, optional): function/transform applied on
-            the target. Default: `None`
+            the target.
+            Default: `None`
 
     Example:
         >>> import sounddevice as sd

--- a/docs/api-datasets.rst
+++ b/docs/api-datasets.rst
@@ -25,6 +25,12 @@ MozillaCommonVoice
 .. autoclass:: MozillaCommonVoice
     :members:
 
+SpeechCommands
+--------------
+
+.. autoclass:: SpeechCommands
+    :members:
+
 VoxCeleb1
 ---------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,7 @@
 
 .. toctree::
     :caption: Getting started
+    :hidden:
 
     install
     usage
@@ -16,6 +17,7 @@
 .. you want to create something different than HTML output.
 .. toctree::
     :caption: API Documentation
+    :hidden:
 
     api-collate
     api-datasets


### PR DESCRIPTION
### Summary

* Remove TOC from index (start) page
* Add `datasets.SpeechCommands` to docs