### PR TITLE
Fix #58

### DIFF
--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -582,7 +582,7 @@ class MaskSpectrogramTime(RandomMask):
 
     """
     def __init__(self, coverage, *, max_width=11, value=0):
-        super().__init__(coverage, max_width, value, axis=1)
+        super().__init__(coverage, max_width, value, axis=-1)
 
 
 class MaskSpectrogramFrequency(RandomMask):
@@ -612,7 +612,7 @@ class MaskSpectrogramFrequency(RandomMask):
 
     """
     def __init__(self, coverage, *, max_width=8, value=0):
-        super().__init__(coverage, max_width, value, axis=0)
+        super().__init__(coverage, max_width, value, axis=-2)
 
 
 class Downmix(object):


### PR DESCRIPTION
### Summary

Fixes #58 


### Proposed Changes

Increase `axis` values of both `transforms.MaskSpectrogramFrequency` and `transforms.MaskSpectrogramTime` by `+1`

### Code
```python
from librosa.display import specshow
import matplotlib.pyplot as plt
from audtorch.datasets import LibriSpeech
from audtorch.transforms import Compose, Spectrogram, MaskSpectrogramFrequency

root = ''  # TODO
data = LibriSpeech(root=root, sets='dev-clean', transform=Compose([Spectrogram(320, 160), MaskSpectrogramFrequency(0.05)]))
magnitude = data[0][0].squeeze().numpy()
specshow(np.log10(np.abs(magnitude) + 1e-4))
plt.show()
```

Also try out with `MaskSpectrogramTime`