### PR TITLE
Include all modules in wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
     Topic :: Multimedia :: Sound/Audio
 
 [options]
-packages = audtorch
+packages = find:
 setup_requires = 
     setuptools_scm
 install_requires =


### PR DESCRIPTION
### Summary

Fixes the content of the wheel package


### Proposed Changes

I thought that using `packages = audtorch` is sufficient, but this only works if you don't have sub-folders (or if you use `include_package_data = True`).
I changed it now to `packages = find:` and it works:

```bash
$ python setup.py sdist bdist_wheel
...
creating build/bdist.linux-x86_64/wheel/audtorch-0.4.2.dev1+g93bbc93.d20191104.dist-info/WHEEL
creating 'dist/audtorch-0.4.2.dev1+g93bbc93.d20191104-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'audtorch/__init__.py'
adding 'audtorch/collate.py'                    
adding 'audtorch/samplers.py'                 
adding 'audtorch/utils.py'
adding 'audtorch/datasets/__init__.py'                  
adding 'audtorch/datasets/audio_set.py'
adding 'audtorch/datasets/base.py'
adding 'audtorch/datasets/libri_speech.py'
adding 'audtorch/datasets/mixture.py'                       
adding 'audtorch/datasets/mozilla_common_voice.py'
adding 'audtorch/datasets/speech_commands.py'                        
adding 'audtorch/datasets/utils.py'
adding 'audtorch/datasets/voxceleb1.py'                             
adding 'audtorch/datasets/white_noise.py'                            
adding 'audtorch/metrics/__init__.py'
adding 'audtorch/metrics/functional.py'
adding 'audtorch/metrics/losses.py'        
adding 'audtorch/metrics/metrics.py'                                       
adding 'audtorch/transforms/__init__.py'
adding 'audtorch/transforms/functional.py'              
adding 'audtorch/transforms/transforms.py'
adding 'audtorch-0.4.2.dev1+g93bbc93.d20191104.dist-info/LICENSE'
adding 'audtorch-0.4.2.dev1+g93bbc93.d20191104.dist-info/METADATA'
adding 'audtorch-0.4.2.dev1+g93bbc93.d20191104.dist-info/WHEEL'
adding 'audtorch-0.4.2.dev1+g93bbc93.d20191104.dist-info/top_level.txt'
adding 'audtorch-0.4.2.dev1+g93bbc93.d20191104.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
```
