### PR TITLE
Enhance basic data sets

### DIFF
--- a/audtorch/datasets/audio_set.py
+++ b/audtorch/datasets/audio_set.py
@@ -40,8 +40,7 @@ class AudioSet(AudioDataset):
       of the data set
 
     Args:
-        root (str, optional): root directory of dataset.
-            Default: `AudioSet.root`
+        root (str): root directory of dataset
         csv_file (str, optional): name of a CSV file located in `root`. Can be
             one of `balanced_train_segments.csv`,
             `unbalanced_train_segments.csv`, `eval_segments.csv`.
@@ -131,9 +130,16 @@ class AudioSet(AudioDataset):
             'Acoustic environment', 'Noise', 'Sound reproduction']
     }
 
-    def __init__(self, root, csv_file='balanced_train_segments.csv',
-                 sampling_rate=16000, include=None, exclude=None,
-                 transform=None, target_transform=None):
+    def __init__(
+            self,
+            root,
+            csv_file='balanced_train_segments.csv',
+            sampling_rate=16000,
+            include=None,
+            exclude=None,
+            transform=None,
+            target_transform=None
+    ):
         root = safe_path(root)
         # Allow only official CSV files as no audio paths are defined otherwise
         assert csv_file in ['eval_segments.csv', 'balanced_train_segments.csv',
@@ -155,12 +161,16 @@ class AudioSet(AudioDataset):
         categories = df['ids'].map(self._convert_ids_to_categories)
 
         audio_folder = os.path.splitext(os.path.basename(csv_file))[0]
-        file_root = os.path.join(root, audio_folder)
-        files = [os.path.join(file_root, f) for f in df['filename']]
+        files = [os.path.join(audio_folder, f) for f in df['filename']]
 
-        super().__init__(root, files, targets=categories, sampling_rate=16000,
-                         transform=transform,
-                         target_transform=target_transform)
+        super().__init__(
+            files=files,
+            targets=categories,
+            sampling_rate=16000,
+            root=root,
+            transform=transform,
+            target_transform=target_transform,
+        )
         self.csv_file = csv_file
         self.include = include
         self.exclude = exclude

--- a/audtorch/datasets/base.py
+++ b/audtorch/datasets/base.py
@@ -199,7 +199,7 @@ class PandasDataset(AudioDataset):
         column_labels (str or list of str, optional): name of data frame
             column(s) containing the desired labels. Default: `label`
         column_filename (str, optional): name of column holding the file
-            names. Default: `filename`
+            names. Default: `file`
         column_start (str, optional): name of column holding start of audio
             in the corresponding file in seconds. Default: `None`
         column_end (str, optional): name of column holding end of audio
@@ -233,7 +233,7 @@ class PandasDataset(AudioDataset):
             sampling_rate,
             root=None,
             column_labels=None,
-            column_filename='filename',
+            column_filename='file',
             column_start=None,
             column_end=None,
             transform=None,
@@ -301,7 +301,7 @@ class CsvDataset(PandasDataset):
         column_labels (str or list of str, optional): name of CSV column(s)
             containing the desired labels. Default: `label`
         column_filename (str, optional): name of CSV column holding the file
-            names. Default: `filename`
+            names. Default: `file`
         column_start (str, optional): name of column holding start of audio
             in the corresponding file in seconds. Default: `None`
         column_end (str, optional): name of column holding end of audio
@@ -336,7 +336,7 @@ class CsvDataset(PandasDataset):
             root=None,
             sep=',',
             column_labels=None,
-            column_filename='filename',
+            column_filename='file',
             column_start=None,
             column_end=None,
             transform=None,

--- a/audtorch/datasets/base.py
+++ b/audtorch/datasets/base.py
@@ -26,6 +26,8 @@ class AudioDataset(Dataset):
     * :attr:`target_transform` controls the target transform
     * :attr:`files` controls the audio files of the data set
     * :attr:`targets` controls the corresponding targets
+    * :attr:`duration` controls audio duration for every file in seconds
+    * :attr:`offset` controls audio offset for every file in seconds
     * :attr:`sampling_rate` holds the sampling rate of the returned data
     * :attr:`original_sampling_rate` holds the sampling rate of the audio files
       of the data set
@@ -65,6 +67,10 @@ class AudioDataset(Dataset):
         self.transform = transform
         self.target_transform = target_transform
 
+        # Initialize empty duration and offset attributes.
+        self.duration = [None] * self.__len__()
+        self.offset = [0] * self.__len__()
+
         assert len(files) == len(targets)
 
         if not self._check_exists():
@@ -74,7 +80,12 @@ class AudioDataset(Dataset):
         return len(self.files)
 
     def __getitem__(self, index):
-        signal, signal_sampling_rate = load(self.files[index])
+
+        signal, signal_sampling_rate = load(
+            self.files[index],
+            duration=self.duration[index],
+            offset=self.offset[index],
+        )
         # Handle empty signals
         if signal.shape[1] == 0:
             warn('Returning previous file.', UserWarning)

--- a/audtorch/datasets/base.py
+++ b/audtorch/datasets/base.py
@@ -66,10 +66,10 @@ class AudioDataset(Dataset):
 
     def __init__(
             self,
+            *,
             files,
             targets,
             sampling_rate,
-            *,
             root=None,
             transform=None,
             target_transform=None
@@ -228,9 +228,9 @@ class PandasDataset(AudioDataset):
 
     def __init__(
             self,
+            *,
             df,
             sampling_rate,
-            *,
             root=None,
             column_labels='label',
             column_filename='filename',
@@ -329,9 +329,9 @@ class CsvDataset(PandasDataset):
 
     def __init__(
             self,
+            *,
             csv_file,
             sampling_rate,
-            *,
             root=None,
             sep=',',
             column_labels='label',
@@ -348,8 +348,8 @@ class CsvDataset(PandasDataset):
                                     .format(self.csv_file))
         df = pd.read_csv(self.csv_file, sep)
         super().__init__(
-            df,
-            sampling_rate,
+            df=df,
+            sampling_rate=sampling_rate,
             root=root,
             column_labels=column_labels,
             column_filename=column_filename,

--- a/audtorch/datasets/base.py
+++ b/audtorch/datasets/base.py
@@ -232,7 +232,7 @@ class PandasDataset(AudioDataset):
             df,
             sampling_rate,
             root=None,
-            column_labels='label',
+            column_labels=None,
             column_filename='filename',
             column_start=None,
             column_end=None,
@@ -263,7 +263,8 @@ class PandasDataset(AudioDataset):
             self.duration = (end - start).where((pd.notnull(end)), None)
 
     def extra_repr(self):
-        fmt_str = '    Labels: {}\n'.format(self.column_labels)
+        if self.column_labels is not None:
+            fmt_str = '    Labels: {}\n'.format(self.column_labels)
         return fmt_str
 
 
@@ -334,7 +335,7 @@ class CsvDataset(PandasDataset):
             sampling_rate,
             root=None,
             sep=',',
-            column_labels='label',
+            column_labels=None,
             column_filename='filename',
             column_start=None,
             column_end=None,

--- a/audtorch/datasets/base.py
+++ b/audtorch/datasets/base.py
@@ -287,6 +287,10 @@ class CsvDataset(PandasDataset):
             containing the desired labels. Default: `label`
         column_filename (str, optional): name of CSV column holding the file
             names. Default: `filename`
+        column_start (str, optional): name of column holding start of audio
+            in the corresponding file in seconds. Default: `None`
+        column_end (str, optional): name of column holding end of audio
+            in the corresponding file in seconds. Default: `None`
         sep (str, optional): CSV delimiter. Default: `,`
         transform (callable, optional): function/transform applied on the
             signal. Default: `None`
@@ -311,9 +315,20 @@ class CsvDataset(PandasDataset):
 
     """
 
-    def __init__(self, root, csv_file, sampling_rate, *, sep=',',
-                 column_labels='label', column_filename='filename',
-                 transform=None, target_transform=None):
+    def __init__(
+            self,
+            root,
+            csv_file,
+            sampling_rate,
+            *,
+            sep=',',
+            column_labels='label',
+            column_filename='filename',
+            column_start=None,
+            column_end=None,
+            transform=None,
+            target_transform=None
+    ):
         self.root = safe_path(root)
         self.csv_file = os.path.join(self.root, csv_file)
 
@@ -321,10 +336,17 @@ class CsvDataset(PandasDataset):
             raise FileNotFoundError('CSV file {} not found.'
                                     .format(self.csv_file))
         df = pd.read_csv(self.csv_file, sep)
-        super().__init__(root, df, sampling_rate,
-                         column_labels=column_labels,
-                         column_filename=column_filename, transform=transform,
-                         target_transform=target_transform)
+        super().__init__(
+            root,
+            df,
+            sampling_rate,
+            column_labels=column_labels,
+            column_filename=column_filename,
+            column_start=column_start,
+            column_end=column_end,
+            transform=transform,
+            target_transform=target_transform,
+        )
 
     def extra_repr(self):
         fmt_str = super().extra_repr()

--- a/audtorch/datasets/mozilla_common_voice.py
+++ b/audtorch/datasets/mozilla_common_voice.py
@@ -81,14 +81,22 @@ class MozillaCommonVoice(CsvDataset):
                  label_type='text', transform=None, target_transform=None,
                  download=False):
 
+        self.root = safe_path(root)
+        csv_file = os.path.join(root, csv_file)
+
         if download:
-            self.root = safe_path(root)
             self._download()
 
-        super().__init__(root, csv_file, sampling_rate=48000, sep=',',
-                         column_labels=label_type, column_filename='filename',
-                         transform=transform,
-                         target_transform=target_transform)
+        super().__init__(
+            csv_file=csv_file,
+            sampling_rate=48000,
+            root=root,
+            sep=',',
+            column_labels=label_type,
+            column_filename='filename',
+            transform=transform,
+            target_transform=target_transform,
+        )
 
     def _download(self):
         if self._check_exists():

--- a/audtorch/datasets/speech_commands.py
+++ b/audtorch/datasets/speech_commands.py
@@ -130,9 +130,14 @@ class SpeechCommands(AudioDataset):
         #     targets.extend([len(include) for _ in range(n_samples)])
         #     files.extend(random.choices(sf, k=n_samples))
 
-        super().__init__(root, files, targets, sampling_rate,
-                         transform=transform,
-                         target_transform=target_transform)
+        super().__init__(
+            files=files,
+            targets=targets,
+            sampling_rate=sampling_rate,
+            root=root,
+            transform=transform,
+            target_transform=target_transform,
+        )
 
     def add_silence(self, n_samples=3000, same_length=True):
         # https://github.com/audeering/audtorch/pull/49#discussion_r317489141

--- a/audtorch/datasets/utils.py
+++ b/audtorch/datasets/utils.py
@@ -257,14 +257,16 @@ def ensure_df_not_empty(df, labels=None):
         raise RuntimeError(error_message)
 
 
-def files_and_labels_from_df(df, *, root='.', column_labels='label',
-                             column_filename='filename'):
+def files_and_labels_from_df(
+        df,
+        *,
+        column_labels='label',
+        column_filename='filename'
+):
     r"""Extract list of files and labels from dataframe columns.
 
     Args:
-        df (pandas.DataFrame): data frame with filenames and labels. Relative
-            from `root`
-        root (str, optional): root directory of data set. Default: `.`
+        df (pandas.DataFrame): data frame with filenames and labels
         column_labels (str or list of str, optional): name of data frame
             column(s) containing the desired labels. Default: `label`
         column_filename (str, optional): name of column holding the file
@@ -286,7 +288,6 @@ def files_and_labels_from_df(df, *, root='.', column_labels='label',
     """
     if df is None:
         return [], []
-    root = safe_path(root)
     if isinstance(column_labels, str):
         column_labels = [column_labels]
     ensure_df_columns_contain(df, column_labels)
@@ -296,7 +297,6 @@ def files_and_labels_from_df(df, *, root='.', column_labels='label',
     ensure_df_not_empty(df, column_labels)
     # Assign files and labels
     files = df.pop(column_filename).tolist()
-    files = [os.path.join(root, f) for f in files]
     if len(column_labels) == 1:
         # list of strings
         labels = df.values.T[0].tolist()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -114,11 +114,22 @@ def test_ensure_df_not_empty(df):
     pytest.param(df_empty, [], [], marks=xfail(raises=RuntimeError)),
 ])
 def test_files_and_labels_from_df(df, expected_files, expected_labels):
-    files, labels = datasets.files_and_labels_from_df(df,
-                                                      column_filename='a',
-                                                      column_labels='b')
+    files, labels = datasets.files_and_labels_from_df(
+        df,
+        column_filename='a',
+        column_labels='b',
+    )
     assert files == expected_files
     assert labels == expected_labels
+    _, labels = datasets.files_and_labels_from_df(
+        df,
+        column_filename='a',
+        column_labels=None,
+    )
+    if df is None:
+        assert labels == []
+    else:
+        assert labels == [''] * len(df)
 
 
 @pytest.mark.parametrize('key_values,split_func,kwargs,expected', [

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -109,16 +109,14 @@ def test_ensure_df_not_empty(df):
 
 
 @pytest.mark.parametrize('df,expected_files,expected_labels', [
-    (df_ab, ['./0'], [1]),
+    (df_ab, ['0'], [1]),
     (None, [], []),
     pytest.param(df_empty, [], [], marks=xfail(raises=RuntimeError)),
 ])
 def test_files_and_labels_from_df(df, expected_files, expected_labels):
     files, labels = datasets.files_and_labels_from_df(df,
-                                                      root='.',
                                                       column_filename='a',
                                                       column_labels='b')
-    expected_files = [datasets.safe_path(f) for f in expected_files]
     assert files == expected_files
     assert labels == expected_labels
 


### PR DESCRIPTION
### Summary

Improvement of base data classes.


### Proposed Changes

1. Make `root` argument optional as it is totally valid to use absolute paths in file lists. This also makes the overall interface slightly easier to implement.
2. Add `duration` and `offset` attribute to `AudioDataset`, which means all others will have it as well.
3. Add `column_start` and `column_end` to `PandasDataset` and `CsvDataset`, which will be translated into the `duration` and `offset` attributes.
4. Allow for `column_labels=None`, which will return `''` as target
5. All basic data sets in `base.py` are now keyword only to not break the API later on.

### Discussion

What I have not changed, but we discussed it before is:

1. The default value of `column_filename` is still `filename`.
