### PR TITLE
Add ensure minimum length

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
+Unreleased
+----------
+
+* Added: `EnsureMinimumLength` transform
 
 Version 0.4.2 (2019-11-04)
 --------------------------

--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -555,6 +555,39 @@ class RandomMask(object):
         return '{0}({1})'.format(self.__class__.__name__, options)
 
 
+class EnsureMinimumLength(object):
+    r"""Transform that ensures a minimum length for the input signal.
+
+    Uses ``audtorch.Pad`` to pad an input signal to a required length adding
+    trailing zeros.
+
+    Args:
+        length: required length in samples
+        axis: axis to force length on
+
+    Example:
+        >>> np.random.seed(0)
+        >>> a = np.array([[1, 2], [3, 4]])
+        >>> t = EnsureMinimumLength(3)
+        >>> t(a)
+        array([[1, 2, 0],
+               [3, 4, 0]])
+    """
+    def __init__(self, length: int, axis: int = -1):
+        self.length = length
+        self.axis = axis
+
+    def __call__(self, x):
+        if x.shape[self.axis] >= self.length:
+            return x
+        return F.pad(x, (0, self.length - x.shape[self.axis]), axis=self.axis)
+
+    def __repr__(self):
+        options = ('length={0}, axis={1}'
+                   .format(self.length, self.axis))
+        return '{0}({1})'.format(self.__class__.__name__, options)
+
+
 class MaskSpectrogramTime(RandomMask):
     r"""Randomly masks spectrogram along time axis.
 

--- a/docs/api-transforms.rst
+++ b/docs/api-transforms.rst
@@ -59,6 +59,12 @@ Expand
 .. autoclass:: Expand
     :members:
 
+EnsureMinimumLength
+-------------------
+
+.. autoclass:: EnsureMinimumLength
+    :members:
+
 RandomMask
 ----------
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -214,6 +214,20 @@ def test_randompad(input, padding, value, axis):
     assert np.array_equal(t(input), expected_output)
 
 
+@pytest.mark.parametrize('signal,length,axis,expected_signal', [
+    (A, 4, -1, A),
+    (A, 3, -1, A),
+    (a11, 5, -1, np.concatenate((a11, [0]), axis=-1)),
+    (a11, 6, -1, np.concatenate((a11, [0, 0]), axis=-1)),
+    (np.array([a11, a12]), 6, -1, np.concatenate(
+        (np.array([a11, a12]), [[0, 0], [0, 0]]), axis=-1))
+])
+def test_ensure_minimum_length(signal, length, axis, expected_signal):
+    t = transforms.EnsureMinimumLength(length, axis=axis)
+    output_signal = t(signal)
+    assert np.array_equal(output_signal, expected_signal)
+
+
 @pytest.mark.parametrize('input,input_sample_rate,output_sample_rate,axis', [
     (A, 4, 2, -1),
     (np.ones([4, 4, 2]), 4, 2, -2),


### PR DESCRIPTION
### Summary

Adds `EnsureMinimumLength` to make sure that an input signal meets some minimum length requirements.