### PR TITLE
Switch to normal import for librosa

### DIFF
--- a/audtorch/transforms/functional.py
+++ b/audtorch/transforms/functional.py
@@ -1,9 +1,6 @@
+import librosa
 import numpy as np
 import torch
-try:
-    import librosa
-except ImportError:
-    librosa = None
 
 from .. import utils
 

--- a/audtorch/transforms/transforms.py
+++ b/audtorch/transforms/transforms.py
@@ -1,13 +1,10 @@
 import random
 from warnings import warn
 
+import librosa
 import numpy as np
 import resampy
 import torch
-try:
-    import librosa
-except ImportError:
-    librosa = None
 try:
     import scipy
 except ImportError:


### PR DESCRIPTION
### Summary

We added `librosa` now as a dependency in `setup.cfg`, which means we can switch to a normal import of it in the transforms.


### Proposed Changes

Replace `try`-`except` with simple `import`.