### PR TITLE
Switch from url to home-page in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,12 +2,12 @@
 name = audtorch
 author = Andreas Triantafyllopoulos, Stephan Huber, Johannes Wagner, Hagen Wierstorf
 author-email = atriant@audeering.com
+home-page = https://audtorch.readthedocs.io
 description = Deep learning with PyTorch and audio
 long_description = file: README.rst, CHANGELOG.rst
 license = MIT License
 license-file = LICENSE
 keywords = audio, torch
-url = https://github.com/audeering/audtorch
 project_urls = 
     Documentation = https://audtorch.readthedocs.io
     Tracker = https://github.com/audeering/audtorch/issues


### PR DESCRIPTION
* Switched from `url` to `home-page` in `setup.cfg` to be in line with our other packages.
* Switched to the documentation as URL
