### PR TITLE
Automate publication of doc and Python package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    # PyPI package
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        python -m twine upload dist/*
+    # Docuemntation
+    - name: Install doc dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install -r docs/requirements.txt
+    - name: Build documentation
+      run: |
+        python -m sphinx docs/ docs/_build/ -b html
+    - name: Deploy documentation to Github pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/_build
+    # Github release
+    - name: Read CHANGELOG
+      id: changelog
+      run: |
+        # Get bullet points from last CHANGELOG entry
+        CHANGELOG=$(git diff -U0 HEAD^ HEAD | grep '^[+][\* ]' | sed 's/\+//')
+        # Support for multiline, see
+        # https://github.com/actions/create-release/pull/11#issuecomment-640071918
+        CHANGELOG="${CHANGELOG//'%'/'%25'}"
+        CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+        CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+        echo "Got changelog: $CHANGELOG"
+        echo "::set-output name=body::$CHANGELOG"
+    - name: Create release on Github
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body: ${{ steps.changelog.outputs.body }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -138,18 +138,6 @@ Creating a New Release
 New releases are made using the following steps:
 
 #. Update ``CHANGELOG.rst``
-#. Commit those changes as "Release x.y.z"
-#. Create an (annotated) tag with ``git tag -a x.y.z``
-#. Clear the ``dist/`` directory
-#. Create a source distribution with ``python setup.py sdist``
-#. Create a wheel distribution with ``python setup.py bdist_wheel``
-#. Check that both files have the correct content
-#. Upload them to PyPI_ with twine_: ``python -m twine upload dist/*``
-#. Push the commit and the tag to Github and `add release notes`_ containing
-   the bullet points from ``CHANGELOG.rst``
-#. Check that the new release was built correctly on `Read The Docs`_, and
-   select the new release as default version
-
-.. _twine: https://twine.readthedocs.io/
-.. _add release notes: https://github.com/audeering/audtorch/releases/
-.. _Read The Docs: https://readthedocs.org/projects/audtorch/builds/
+#. Commit those changes as "Release X.Y.Z"
+#. Create an (annotated) tag with ``git tag -a X.Y.Z``
+#. Push the commit and the tag to Github


### PR DESCRIPTION
Uses a Github Action to:

* build and upload docs as Github pages
* build and upload Python package to PyPI server
* create a release on Github including the latest changelog automatically