### PR TITLE
Only install doc requirements when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,12 +30,9 @@ jobs:
         python -m twine upload dist/*
     # Docuemntation
     - name: Install doc dependencies
-      run: |
-        pip install -r requirements.txt
-        pip install -r docs/requirements.txt
+      run: pip install -r docs/requirements.txt
     - name: Build documentation
-      run: |
-        python -m sphinx docs/ docs/_build/ -b html
+      run: python -m sphinx docs/ docs/_build/ -b html
     - name: Deploy documentation to Github pages
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
The last publishing failed when trying to install `torch`: https://github.com/audeering/audtorch/runs/1330863465?check_suite_focus=true

But this is also not needed for just building the documentation.
