### PR TITLE
Update documentation link in Python package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,8 @@ license-file = LICENSE
 keywords = audio, torch
 url = https://github.com/audeering/audtorch
 project_urls = 
-    Documentation = https://audtorch.readthedocs.io
-    Tracker = https://github.com/audeering/audtorch/issues
+    Documentation = https://audeering.github.io/audtorch/
+    Tracker = https://github.com/audeering/audtorch/issues/
 platforms = any
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Fix link in Python package to point to documentation on Github pages
