### PR TITLE
DOC: use sphinxcontrib-bibtex>=2.1.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,6 +76,7 @@ nbsphinx_execute = 'never'
 linkcheck_ignore = [
     'https://doi.org/',  # has timeouts from time to time
 ]
+bibtex_bibfiles = ['refs.bib']
 
 # HTML --------------------------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ nbsphinx
 sphinx
 sphinx-audeering-theme >=0.9.0
 sphinxcontrib-katex
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex >=2.1.0
 sphinx-copybutton


### PR DESCRIPTION
### Summary

The new version of `sphinxcontrib-bibtex` requires another config entry, otherwise it will break the compilation of the docs.
