### PR TITLE
Update Python package metadata syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = audtorch
 author = Andreas Triantafyllopoulos, Stephan Huber, Johannes Wagner, Hagen Wierstorf
-author-email = atriant@audeering.com
+author_email = atriant@audeering.com
 description = Deep learning with PyTorch and audio
 long_description = file: README.rst, CHANGELOG.rst
 license = MIT License
-license-file = LICENSE
+license_file = LICENSE
 keywords = audio, torch
 url = https://github.com/audeering/audtorch
 project_urls = 


### PR DESCRIPTION
Replace deprecated `abc-def` entries with `abc_def` in `setup.cfg`.