### PR TITLE
WIP: Add datasets.AudFormat

### DIFF
--- a/audtorch/datasets/__init__.py
+++ b/audtorch/datasets/__init__.py
@@ -1,3 +1,4 @@
+from .audformat import *
 from .audio_set import *
 from .base import *
 from .emodb import *

--- a/docs/api-datasets.rst
+++ b/docs/api-datasets.rst
@@ -6,6 +6,12 @@ Audio data sets.
 .. automodule:: audtorch.datasets
 
 
+AudFormat
+---------
+
+.. autoclass:: AudFormat
+    :members:
+
 AudioSet
 --------
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+audformat
 pytest
 pytest-cov
 pytest-flake8


### PR DESCRIPTION
To make our internal `audtorch_internal` package obsolete we add `audformat` support here.
